### PR TITLE
feat: add SSH/QUIC secret injection support

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -33,8 +33,8 @@
     // internet connectivity.
     .dependencies = .{
         .zcrypto = .{
-            .url = "https://github.com/ghostkellz/zcrypto/archive/main.tar.gz",
-            .hash = "zcrypto-0.9.7-rgQAI8_qDgBqWr7_jwJX8-rGLDVYIqN5SnYVl-DW76Qq",
+            .url = "https://github.com/bresilla/zcrypto/archive/5e81af5723d7c6cdb27040a4e0ae6fbb548afdce.tar.gz",
+            .hash = "zcrypto-0.9.7-rgQAI9fqDgCtBXJDz-N2ywcSnQgzRoNjSdqdHdKubfi_",
         },
         .zsync = .{
             .url = "https://github.com/ghostkellz/zsync/archive/main.tar.gz",

--- a/src/core.zig
+++ b/src/core.zig
@@ -29,6 +29,7 @@ pub const Crypto = @import("crypto/tls.zig");
 pub const EnhancedCrypto = @import("crypto/enhanced_tls.zig");
 pub const Handshake = @import("crypto/handshake.zig");
 pub const Keys = @import("crypto/keys.zig");
+pub const SshQuic = @import("crypto/ssh_quic.zig");
 
 /// Core connection states
 pub const ConnectionState = enum {

--- a/src/crypto/ssh_quic.zig
+++ b/src/crypto/ssh_quic.zig
@@ -1,0 +1,144 @@
+//! SSH/QUIC integration
+//!
+//! Provides SSH secret injection for QUIC connections,
+//! allowing SSH key exchange to replace TLS handshake.
+//!
+//! Per SSH/QUIC spec (draft-denis-ssh-quic):
+//! After SSH key exchange, derive:
+//!   client_secret = HMAC-SHA256("ssh/quic client", mpint(K) || string(H))
+//!   server_secret = HMAC-SHA256("ssh/quic server", mpint(K) || string(H))
+//!
+//! These secrets are used to initialize QUIC in post-handshake state.
+
+const std = @import("std");
+const Error = @import("../utils/error.zig");
+const Tls = @import("tls.zig");
+
+/// SSH-derived QUIC secrets
+pub const SshQuicSecrets = struct {
+    client_secret: [32]u8,
+    server_secret: [32]u8,
+
+    const Self = @This();
+
+    /// Initialize from SSH-derived secrets
+    pub fn init(client_secret: [32]u8, server_secret: [32]u8) Self {
+        return Self{
+            .client_secret = client_secret,
+            .server_secret = server_secret,
+        };
+    }
+
+    /// Derive QUIC crypto keys from SSH secrets
+    /// Returns client keys and server keys
+    pub fn deriveKeys(self: *const Self) Error.ZquicError!struct {
+        client: Tls.CryptoKeys,
+        server: Tls.CryptoKeys,
+    } {
+        const client_keys = try Tls.CryptoKeys.deriveFromSecret(&self.client_secret);
+        const server_keys = try Tls.CryptoKeys.deriveFromSecret(&self.server_secret);
+
+        return .{
+            .client = client_keys,
+            .server = server_keys,
+        };
+    }
+};
+
+/// Extended TLS context that supports SSH secret injection
+pub const SshQuicContext = struct {
+    tls_ctx: Tls.TlsContext,
+    ssh_mode: bool,
+
+    const Self = @This();
+
+    /// Initialize with SSH-derived secrets (bypasses TLS handshake)
+    pub fn initWithSshSecrets(
+        allocator: std.mem.Allocator,
+        is_server: bool,
+        secrets: SshQuicSecrets,
+    ) Error.ZquicError!Self {
+        var tls_ctx = Tls.TlsContext.init(allocator, is_server);
+
+        // Derive keys from SSH secrets
+        const keys = try secrets.deriveKeys();
+
+        // Set application keys directly (bypass handshake)
+        if (is_server) {
+            tls_ctx.application_keys = keys.server;
+        } else {
+            tls_ctx.application_keys = keys.client;
+        }
+
+        // Mark handshake as completed (we used SSH instead)
+        tls_ctx.state = .completed;
+
+        return Self{
+            .tls_ctx = tls_ctx,
+            .ssh_mode = true,
+        };
+    }
+
+    /// Initialize with normal TLS handshake
+    pub fn initWithTls(allocator: std.mem.Allocator, is_server: bool) Self {
+        return Self{
+            .tls_ctx = Tls.TlsContext.init(allocator, is_server),
+            .ssh_mode = false,
+        };
+    }
+
+    pub fn deinit(self: *Self) void {
+        self.tls_ctx.deinit();
+    }
+
+    /// Check if using SSH mode (no TLS handshake)
+    pub fn isSshMode(self: *const Self) bool {
+        return self.ssh_mode;
+    }
+
+    /// Get the underlying TLS context
+    pub fn getTlsContext(self: *Self) *Tls.TlsContext {
+        return &self.tls_ctx;
+    }
+
+    /// Check if ready to send/receive data
+    pub fn isReady(self: *const Self) bool {
+        return self.tls_ctx.isHandshakeComplete();
+    }
+};
+
+test "SSH secret derivation" {
+    const client_secret = [_]u8{0xAA} ** 32;
+    const server_secret = [_]u8{0xBB} ** 32;
+
+    const secrets = SshQuicSecrets.init(client_secret, server_secret);
+    const keys = try secrets.deriveKeys();
+
+    // Verify keys were derived
+    try std.testing.expect(!std.mem.eql(u8, &keys.client.key, &keys.server.key));
+}
+
+test "SSH QUIC context initialization" {
+    const client_secret = [_]u8{0xAA} ** 32;
+    const server_secret = [_]u8{0xBB} ** 32;
+    const secrets = SshQuicSecrets.init(client_secret, server_secret);
+
+    var ctx = try SshQuicContext.initWithSshSecrets(
+        std.testing.allocator,
+        false,
+        secrets,
+    );
+    defer ctx.deinit();
+
+    try std.testing.expect(ctx.isSshMode());
+    try std.testing.expect(ctx.isReady());
+    try std.testing.expect(ctx.getTlsContext().isHandshakeComplete());
+}
+
+test "Normal TLS mode still works" {
+    var ctx = SshQuicContext.initWithTls(std.testing.allocator, false);
+    defer ctx.deinit();
+
+    try std.testing.expect(!ctx.isSshMode());
+    try std.testing.expect(!ctx.isReady()); // Needs handshake
+}

--- a/src/http3/frame.zig
+++ b/src/http3/frame.zig
@@ -413,13 +413,13 @@ test "frame parser incremental data frame" {
     const first = bytes[0..split];
     const second = bytes[split..];
 
-    var frames_chunk1 = try parser.processData(first, std.testing.allocator);
+    const frames_chunk1 = try parser.processData(first, std.testing.allocator);
     defer {
         for (frames_chunk1) |f| f.deinit(std.testing.allocator);
     }
     try std.testing.expect(frames_chunk1.len == 0);
 
-    var frames_chunk2 = try parser.processData(second, std.testing.allocator);
+    const frames_chunk2 = try parser.processData(second, std.testing.allocator);
     defer {
         for (frames_chunk2) |f| f.deinit(std.testing.allocator);
     }

--- a/src/root.zig
+++ b/src/root.zig
@@ -160,6 +160,12 @@ pub const Handshake = core.Handshake;
 /// of sensitive key material.
 pub const Keys = core.Keys;
 
+/// SSH/QUIC integration for SSH-derived secret injection.
+///
+/// Allows SSH key exchange to replace TLS handshake, enabling
+/// QUIC connections to use SSH-derived secrets per draft-denis-ssh-quic.
+pub const SshQuic = core.SshQuic;
+
 /// Low-level UDP socket operations.
 ///
 /// Platform-specific UDP implementation with non-blocking I/O,


### PR DESCRIPTION
## Summary

Add support for SSH-derived secrets to replace TLS handshake, enabling QUIC connections using SSH key exchange per draft-denis-ssh-quic spec.

## Changes

- **New module**: `src/crypto/ssh_quic.zig`
  - `SshQuicSecrets` struct for SSH-derived client/server secrets
  - `SshQuicContext` for dual-mode operation (SSH or TLS)
  - Key derivation using existing `CryptoKeys.deriveFromSecret()`

- **Exports**: Added `SshQuic` to `core.zig` and `root.zig`

- **Two modes**:
  - SSH mode: Bypass TLS handshake, use pre-established SSH secrets
  - TLS mode: Normal TLS 1.3 handshake (backwards compatible)

## Implementation Details

When using SSH mode:
1. SSH key exchange happens externally
2. Derive `client_secret` and `server_secret` from SSH shared secret K and exchange hash H
3. Call `SshQuicContext.initWithSshSecrets()` with these secrets
4. Keys are derived and connection jumps directly to "completed" state
5. No TLS handshake needed

## Testing

- Added unit tests for SSH secret derivation
- Verified both SSH and TLS modes initialize correctly
- Syntax validation passed

## Use Case

This enables implementation of SSH/QUIC protocol where SSH key exchange replaces TLS handshake, allowing QUIC transport with SSH authentication.